### PR TITLE
Fix nth best road indexing

### DIFF
--- a/zombies.py
+++ b/zombies.py
@@ -517,8 +517,8 @@ class Model:
         if n > len(sorted_indices):
             raise ValueError(f"Cannot find the {n}th best road as there are only {len(sorted_indices)} roads.")
 
-        # Return the road with the nth-shortest distance
-        return self.roads[sorted_indices[1]]
+        # Return the road with the nth-shortest distance (1-indexed)
+        return self.roads[sorted_indices[n - 1]]
 
 
     


### PR DESCRIPTION
## Summary
- correct indexing in `find_nth_best_road` so it uses `n - 1`

## Testing
- `python -m py_compile zombies.py`

------
https://chatgpt.com/codex/tasks/task_e_68754e575dbc832d8630c4984342a7dc