### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENT Instructions
+
+## Setup
+Run `./setup.sh` to create a virtual environment and install the dependencies. This project requires MPI tools to build `repast4py`. If the tools are not available the installation may fail.
+
+## Testing
+Execute `pytest` from the repository root. The tests rely on the packages listed in `requirements.txt`.
+
+## Style
+Follow [PEP8](https://peps.python.org/pep-0008/) conventions and format Python code with `black`.
+


### PR DESCRIPTION
## Summary
- add AGENTS.md at repo root with setup, test, and style guidance

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687561972cec832d9f000d8a94922631