### PR TITLE
Fix repast4py install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENT Instructions
 
 ## Setup
-Run `./setup.sh` to create a virtual environment and install the dependencies. This project requires MPI tools to build `repast4py`. If the tools are not available the installation may fail.
+Run `./setup.sh` to create a virtual environment and install the dependencies. The script expects MPI compilers (`mpicc` and `mpic++`) to be available so that `repast4py` can be built. It installs a CPU-only build of PyTorch first to avoid downloading large GPU binaries.
 
 ## Testing
 Execute `pytest` from the repository root. The tests rely on the packages listed in `requirements.txt`.

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,8 @@ export CC=mpicc
 export CXX=mpic++
 
 python -m pip install --upgrade pip
+# Install CPU-only PyTorch first so repast4py doesn't pull in GPU builds
+python -m pip install "torch==2.2.2+cpu" --index-url https://download.pytorch.org/whl/cpu
 python -m pip install -r requirements.txt
 
 echo "Setup complete. Activate the environment with 'source $VENV_DIR/bin/activate'"


### PR DESCRIPTION
## Summary
- document MPI compiler requirement and CPU torch usage
- install CPU-only PyTorch in setup.sh before other deps

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687587b85070832db9a96b7b7d05e4a7