### PR TITLE
Fix repast4py fallback logic and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ source venv/bin/activate
 
 The dependencies are listed in `requirements.txt`.
 
+The setup script assumes you have MPI compilers (`mpicc` and `mpic++`) installed.
+On Debian or Ubuntu systems you can install them with:
+
+```bash
+sudo apt-get install openmpi-bin libopenmpi-dev
+```
+
 ## Importing Roads from OpenStreetMap
 
 An optional utility allows creating `Road` objects directly from OpenStreetMap data. The function fetches a street network using [OSMnx](https://github.com/gboeing/osmnx) and converts each edge into a road.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,27 +1,41 @@
-import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import sys, os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import numpy as np
-from zombies import is_equal, distance, dot_product, generate_grid_roads, import_osm_roads
+from zombies import (
+    is_equal,
+    distance,
+    dot_product,
+    generate_grid_roads,
+    import_osm_roads,
+)
 import networkx as nx
 
+
 def test_is_equal_true():
-    a=np.array([1,2])
-    b=np.array([1,2])
-    assert is_equal(a,b)
+    a = np.array([1, 2])
+    b = np.array([1, 2])
+    assert is_equal(a, b)
+
 
 def test_is_equal_false():
-    a=np.array([1,2])
-    b=np.array([2,1])
-    assert not is_equal(a,b)
+    a = np.array([1, 2])
+    b = np.array([2, 1])
+    assert not is_equal(a, b)
+
 
 def test_distance():
-    assert distance(0,0,3,4)==5
+    assert distance(0, 0, 3, 4) == 5
+
 
 def test_dot_product():
-    assert dot_product(1,2,3,4)==11
+    assert dot_product(1, 2, 3, 4) == 11
+
 
 def test_generate_grid_roads_count():
-    roads=generate_grid_roads(100,100,20)
-    assert len(roads)==50
+    roads = generate_grid_roads(100, 100, 20)
+    assert len(roads) == 50
+
 
 def test_import_osm_roads_from_graph():
     G = nx.MultiDiGraph()
@@ -32,4 +46,4 @@ def test_import_osm_roads_from_graph():
     G.add_edge(1, 2)
     roads = import_osm_roads(graph=G)
     assert len(roads) == 2
-    assert all(hasattr(r, 'start') and hasattr(r, 'end') for r in roads)
+    assert all(hasattr(r, "start") and hasattr(r, "end") for r in roads)

--- a/zombies.py
+++ b/zombies.py
@@ -22,6 +22,8 @@ try:
     from repast4py.space import ContinuousPoint as cpt
     from repast4py.space import DiscretePoint as dpt
     from repast4py.space import BorderType, OccupancyType
+
+    REPAST4PY_AVAILABLE = True
 except Exception:  # pragma: no cover - repast4py may be unavailable during testing
 
     class _DummyAgent:
@@ -35,6 +37,7 @@ except Exception:  # pragma: no cover - repast4py may be unavailable during test
     create_args_parser = init_params = lambda *args, **kwargs: None
     cpt = dpt = None
     BorderType = OccupancyType = None
+    REPAST4PY_AVAILABLE = False
 BATCH_SIZE = 1000
 model = None
 RADIUSSEARCH = 20


### PR DESCRIPTION
## Summary
- add `REPAST4PY_AVAILABLE` flag in `zombies.py`
- reformat tests with `black`
- document MPI requirement for running `setup.sh`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875913d8eb4832d97ac22f41b07afc7